### PR TITLE
Automate tagged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - "**"
   pull_request:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,160 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-version:
+    name: Verify release version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Validate tag and VERSION
+        id: version
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="$(tr -d '\r\n' < VERSION)"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must use vMAJOR.MINOR.PATCH, got: $tag" >&2
+            exit 1
+          fi
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "VERSION must use MAJOR.MINOR.PATCH, got: $version" >&2
+            exit 1
+          fi
+          if [[ "$tag" != "v$version" ]]; then
+            echo "Release tag $tag does not match VERSION $version" >&2
+            exit 1
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+  build-unix:
+    name: Build release (${{ matrix.name }})
+    needs: verify-version
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu
+            os: ubuntu-latest
+          - name: macos
+            os: macos-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -S . -B build-cmake -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build with CMake
+        run: cmake --build build-cmake --config Release
+
+      - name: Run CTest suite
+        run: ctest --test-dir build-cmake --output-on-failure
+
+      - name: Create release archives
+        run: cpack --config build-cmake/CPackConfig.cmake -B release-artifacts
+
+      - name: Validate Debian package
+        if: matrix.name == 'ubuntu'
+        run: |
+          dpkg-deb --info release-artifacts/*.deb
+          dpkg-deb --contents release-artifacts/*.deb
+
+      - name: Upload release archives
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.name }}
+          path: release-artifacts/*
+          if-no-files-found: error
+
+  build-windows:
+    name: Build release (windows)
+    needs: verify-version
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -S . -B build-cmake -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build with CMake
+        run: cmake --build build-cmake --config Release
+
+      - name: Run portable CTest checks
+        run: ctest --test-dir build-cmake -C Release --output-on-failure -R "unit_tests|version_command|config_path_command|tunnel_list_command"
+
+      - name: Create Windows ZIP
+        run: cpack -G ZIP --config build-cmake/CPackConfig.cmake -B release-artifacts
+
+      - name: Verify Windows ZIP
+        shell: pwsh
+        run: |
+          $archive = Get-ChildItem release-artifacts -Filter '*.zip'
+          if ($archive.Count -ne 1) { throw 'Expected exactly one Windows ZIP artifact.' }
+          Expand-Archive -LiteralPath $archive.FullName -DestinationPath extracted-artifact -Force
+          $binary = Get-ChildItem extracted-artifact -Filter dgramtunneler.exe -Recurse
+          if ($binary.Count -ne 1) { throw 'Windows ZIP does not contain dgramtunneler.exe.' }
+          & $binary.FullName --version
+
+      - name: Upload Windows ZIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows
+          path: release-artifacts/*.zip
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub Release
+    needs:
+      - verify-version
+      - build-unix
+      - build-windows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download release archives
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: release-artifacts
+
+      - name: Generate checksums
+        shell: bash
+        working-directory: release-artifacts
+        run: |
+          find . -type f -print0 | sort -z | xargs -0 shasum -a 256 > SHA256SUMS
+
+      - name: Create GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mapfile -d '' artifacts < <(find release-artifacts -type f -print0)
+          if [[ "${#artifacts[@]}" -eq 0 ]]; then
+            echo "No release artifacts were downloaded." >&2
+            exit 1
+          fi
+          gh release create "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --verify-tag \
+            --title "DatagramTunneler ${GITHUB_REF_NAME}" \
+            --generate-notes \
+            "${artifacts[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@ bin/*
 
 # ignore local build directories
 /build/
-/build-cmake/
+/build-*/
 /install-test/
-/release-artifacts/
+/release-artifacts*/
 /packaging/homebrew/Formula/dgramtunneler.rb
 
 # local planning notes

--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ This produces `.tar.gz` and `.zip` archives named `dgramtunneler-<version>-<syst
 
 For Homebrew updates, use the [tap release procedure](packaging/homebrew/README.md).
 
+## Publish a release
+
+Pushing a semantic-version tag automatically validates the matching `VERSION` file, builds and tests release packages on macOS, Ubuntu, and Windows, creates the GitHub Release, uploads the artifacts, and attaches a `SHA256SUMS` file.
+
+After merging the version bump to `master`:
+
+```sh
+git tag -a v<version> -m "DatagramTunneler <version>"
+git push origin v<version>
+```
+
+The tag must exactly match `VERSION`: for example, `VERSION` `1.1.0` requires tag `v1.1.0`.
+
 ## Tests
 
 The test suite covers protocol framing, command and configuration parsing, named-tunnel commands, and a loopback multicast round-trip test when Python 3 is available.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -13,7 +13,7 @@ brew install dgramtunneler
 
 ## Per-release update
 
-1. Update `VERSION`, commit it, publish the matching Git tag such as `v1.1.0`, and create the GitHub Release.
+1. Update `VERSION`, commit it, and publish the matching Git tag such as `v1.1.0`. The tag-triggered release workflow validates the version and creates the GitHub Release.
 2. Download the source archive and calculate its checksum:
 
    ```sh


### PR DESCRIPTION
## Summary
- add tag/version validation and tag-triggered cross-platform release publishing
- upload release artifacts and SHA256SUMS automatically
- document the release process and ignore generated build outputs

## Validation
- workflow YAML parsing
- CMake and Makefile builds
- full CTest suite (5/5)