### PR TITLE
Automate Homebrew update pull requests

### DIFF
--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -1,0 +1,90 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish to the Homebrew tap (for example, v1.0.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  create-formula-pr:
+    name: Create Homebrew update PR
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      TAP_REPOSITORY: MarkoPaul0/homebrew-dgramtunneler
+
+    steps:
+      - name: Validate release tag and tap credentials
+        shell: bash
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must use vMAJOR.MINOR.PATCH, got: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          if [[ -z "$TAP_TOKEN" ]]; then
+            echo "HOMEBREW_TAP_TOKEN is required to open a pull request in $TAP_REPOSITORY." >&2
+            exit 1
+          fi
+
+      - name: Check out released source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Render formula from immutable source archive
+        shell: bash
+        run: |
+          archive="dgramtunneler-${RELEASE_TAG}.tar.gz"
+          curl --fail --location --retry 3 --output "$archive" \
+            "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${RELEASE_TAG}.tar.gz"
+          checksum="$(sha256sum "$archive" | awk '{print $1}')"
+          sh packaging/homebrew/render-formula.sh "$RELEASE_TAG" "$checksum"
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.TAP_REPOSITORY }}
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Create formula update pull request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          branch="automation/dgramtunneler-${RELEASE_TAG}"
+          existing_prs="$(gh pr list --repo "$TAP_REPOSITORY" --head "$branch" --state open --json url --jq 'length')"
+          if [[ "$existing_prs" != "0" ]]; then
+            echo "An open Homebrew update pull request already exists for $RELEASE_TAG."
+            exit 0
+          fi
+
+          mkdir -p tap/Formula
+          cp packaging/homebrew/Formula/dgramtunneler.rb tap/Formula/dgramtunneler.rb
+          git -C tap config user.name "github-actions[bot]"
+          git -C tap config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C tap switch -c "$branch"
+          git -C tap add Formula/dgramtunneler.rb
+          if git -C tap diff --cached --quiet; then
+            echo "The Homebrew formula already matches $RELEASE_TAG."
+            exit 0
+          fi
+          git -C tap commit -m "Update dgramtunneler to ${RELEASE_TAG}"
+          git -C tap push origin "HEAD:${branch}"
+          gh pr create \
+            --repo "$TAP_REPOSITORY" \
+            --base main \
+            --head "$branch" \
+            --title "Update dgramtunneler to ${RELEASE_TAG}" \
+            --body "Automated formula update for https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}."

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ For Homebrew updates, use the [tap release procedure](packaging/homebrew/README.
 
 Pushing a semantic-version tag automatically validates the matching `VERSION` file, builds and tests release packages on macOS, Ubuntu, and Windows, creates the GitHub Release, uploads the artifacts, and attaches a `SHA256SUMS` file.
 
+When the Homebrew tap automation is configured, publishing the release also opens a reviewed formula-update pull request in the tap. See the [tap release procedure](packaging/homebrew/README.md) for the one-time credential setup.
+
 After merging the version bump to `master`:
 
 ```sh

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -11,24 +11,20 @@ brew tap MarkoPaul0/dgramtunneler
 brew install dgramtunneler
 ```
 
+## Automation setup
+
+The main repository's `Update Homebrew Formula` workflow opens a reviewed pull request in the tap whenever a GitHub Release is published. Create a fine-grained personal access token with access limited to `MarkoPaul0/homebrew-dgramtunneler` and these permissions:
+
+- **Contents:** read and write, to push the generated formula branch.
+- **Pull requests:** read and write, to open the reviewable update PR.
+
+Store the token as the `HOMEBREW_TAP_TOKEN` Actions secret in the `MarkoPaul0/DatagramTunneler` repository. The release remains successful if this workflow is not configured; the separate formula workflow reports the missing secret clearly. Use its manual-dispatch input with an existing tag to retry a formula update without making another release.
+
 ## Per-release update
 
 1. Update `VERSION`, commit it, and publish the matching Git tag such as `v1.1.0`. The tag-triggered release workflow validates the version and creates the GitHub Release.
-2. Download the source archive and calculate its checksum:
-
-   ```sh
-   curl -L -o dgramtunneler-v1.1.0.tar.gz \
-     https://github.com/MarkoPaul0/DatagramTunneler/archive/refs/tags/v1.1.0.tar.gz
-   shasum -a 256 dgramtunneler-v1.1.0.tar.gz
-   ```
-
-3. Render the formula with the tag and checksum:
-
-   ```sh
-   sh packaging/homebrew/render-formula.sh v1.1.0 <sha256>
-   ```
-
-4. Copy the rendered `packaging/homebrew/Formula/dgramtunneler.rb` to the tap's `Formula/` directory, commit and push it, then verify it:
+2. Review and merge the formula-update PR automatically opened in the tap.
+3. Verify the published formula:
 
    ```sh
    brew install --build-from-source MarkoPaul0/dgramtunneler/dgramtunneler


### PR DESCRIPTION
## Summary
- add a release-triggered workflow that renders the formula from the tagged source archive
- create a reviewed formula update PR in the official Homebrew tap
- document the scoped HOMEBREW_TAP_TOKEN setup and manual retry path

## Validation
- workflow YAML parsing
- CMake and Makefile builds
- full CTest suite (5/5)

## Follow-up
Configure the HOMEBREW_TAP_TOKEN Actions secret before the first release that should update the tap.