### PR TITLE
Improve community health and discoverability

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The maintainer reviews all changes until the project has dedicated owners.
+* @MarkoPaul0

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report a reproducible problem with DatagramTunneler.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a problem.
+
+        Do not include security-sensitive details here. Follow the
+        [security policy](https://github.com/MarkoPaul0/DatagramTunneler/blob/master/SECURITY.md)
+        instead.
+  - type: input
+    id: version
+    attributes:
+      label: DatagramTunneler version
+      description: Include the output of `dgramtunneler --version`.
+      placeholder: "1.0.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the observed result and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal configuration and command sequence.
+      placeholder: |
+        1. Run ...
+        2. Send ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or additional context
+      description: Remove credentials, private addresses, and other sensitive data.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Suggest a focused improvement to DatagramTunneler.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for sharing an idea. For a large API, protocol, or
+        cross-platform change, describing the problem first helps us discuss it
+        before implementation.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What workflow is difficult or unsupported today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the desired behaviour, command, or configuration.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include existing workarounds or other approaches, if any.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Include compatibility, platform, or operational constraints.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+Describe what changed and why.
+
+## Validation
+
+List the commands, tests, and manual checks you ran. Include relevant platform
+coverage when the change affects networking, packaging, or installation.
+
+## Checklist
+
+- [ ] The change is focused and based on the current `master` branch.
+- [ ] Tests were added or updated when behaviour changed.
+- [ ] User documentation was updated when commands, configuration, packages,
+      or supported platforms changed.
+- [ ] Backwards compatibility and platform-specific effects were considered.
+- [ ] No generated build or release artifacts are included.
+
+## Compatibility notes
+
+Describe any breaking change, migration step, or known platform limitation. If
+none apply, write `None`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+## Our commitment
+
+We want participation in DatagramTunneler to be welcoming, respectful, and
+free from harassment for everyone, regardless of background, identity, level
+of experience, or role in the project.
+
+## Expected behaviour
+
+- Be respectful, constructive, and considerate in technical discussion.
+- Assume good intent, ask clarifying questions, and accept useful feedback.
+- Focus criticism on ideas and changes, never on people.
+- Respect differing viewpoints and experiences.
+
+## Unacceptable behaviour
+
+- Harassment, threats, intimidation, or discriminatory language.
+- Personal attacks, trolling, or sustained disruption of discussion.
+- Publishing private information without permission.
+- Any conduct that would reasonably make project spaces unsafe or unwelcoming.
+
+## Scope
+
+This Code of Conduct applies in project spaces, including issues, pull
+requests, discussions, releases, and other interactions representing the
+project.
+
+## Reporting and enforcement
+
+Report a Code of Conduct concern privately to the repository owner through a
+contact method listed on their GitHub profile. Do not include sensitive details
+in a public issue.
+
+The maintainer will review reports promptly and may remove content, issue a
+warning, temporarily restrict participation, or take other appropriate action.
+Reports will be handled as privately as practical.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to DatagramTunneler
+
+Thanks for helping improve DatagramTunneler. Small, focused contributions are
+easiest to review and release.
+
+## Before you start
+
+- Search existing issues and pull requests before opening a new one.
+- Use an issue to discuss larger changes, new public commands, protocol
+  changes, or cross-platform behaviour before implementing them.
+- Keep direct command-line workflows backwards compatible unless the change is
+  explicitly versioned and documented.
+
+## Development setup
+
+DatagramTunneler requires a C++20-capable compiler and CMake 3.16 or newer.
+
+```sh
+cmake -S . -B build-cmake -DBUILD_TESTING=ON
+cmake --build build-cmake
+ctest --test-dir build-cmake --output-on-failure
+```
+
+The test suite covers protocol framing, command and configuration parsing, and
+a loopback multicast round trip when Python 3 is available.
+
+## Pull requests
+
+- Branch from the current `master` branch.
+- Keep each pull request limited to one coherent change.
+- Add or update tests for behaviour changes.
+- Update the README or other user documentation when commands, configuration,
+  packaging, or supported platforms change.
+- Describe the motivation, implementation, validation performed, and any
+  platform-specific considerations in the pull request.
+
+## Code and review expectations
+
+- Follow the existing C++20 and CMake conventions in the surrounding code.
+- Prefer clear ownership, RAII, explicit error handling, and small focused
+  changes over broad rewrites.
+- Do not include generated build directories or release artifacts in commits.
+- Be respectful and constructive in all project interactions; the
+  [Code of Conduct](CODE_OF_CONDUCT.md) applies to all contributors.
+
+## Reporting security issues
+
+Do not open public issues for suspected vulnerabilities. Follow the
+[security policy](SECURITY.md) instead.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,30 @@
 ![GitHub last commit](https://img.shields.io/github/last-commit/MarkoPaul0/DatagramTunneler.svg?style=flat-square&maxAge=300)
 ![Stars](https://img.shields.io/github/stars/MarkoPaul0/DatagramTunneler.svg?style=social)
 
-DatagramTunneler forwards UDP multicast datagrams through a TCP connection. A client joins a multicast group, forwards received datagrams to a server, and the server republishes them on its own subnet.
+DatagramTunneler tunnels UDP multicast datagrams over a TCP connection. A client joins a multicast group, forwards received datagrams to a server, and the server republishes them on its own subnet.
 
 It supports current Linux, macOS, and Windows 10/11 releases, direct command-line use, and reusable named tunnel definitions.
+
+## What it is for
+
+Use DatagramTunneler when a multicast-dependent application needs to cross a
+routed, site-to-site, or test-network boundary. Typical uses include:
+
+- relaying UDP multicast telemetry between two networks;
+- testing multicast applications from a remote environment; and
+- extending LAN-discovery traffic to a second subnet where the source group is
+  otherwise unavailable.
+
+### DatagramTunneler and generic tunnels
+
+DatagramTunneler solves a different problem from generic public-endpoint tools
+such as ngrok. It relays UDP multicast that the client can already receive; it
+does not expose a local service to the public Internet, perform NAT traversal,
+or provide a low-latency UDP transport. TCP's ordering and retransmission
+behaviour can make it unsuitable for latency-sensitive real-time game traffic.
+
+It is a better fit for multicast-dependent workflows such as LAN discovery,
+telemetry, and cross-subnet testing.
 
 ## Install
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are made for the latest released version of DatagramTunneler.
+Please upgrade before reporting an issue whenever practical.
+
+| Version | Supported |
+| --- | --- |
+| Latest release | Yes |
+| Older releases | No |
+
+## Reporting a vulnerability
+
+Please do **not** report security vulnerabilities in public GitHub issues or
+discussions.
+
+Use GitHub's private vulnerability-reporting feature from this repository's
+**Security** tab and include:
+
+- the affected release and operating system;
+- a clear description of the impact;
+- steps or a minimal proof of concept to reproduce the issue; and
+- any mitigations you know of.
+
+We aim to acknowledge reports within seven calendar days, investigate them
+privately, and coordinate a fix and disclosure timeline with the reporter.
+
+If GitHub's private reporting option is unavailable, do not publish the
+details. Contact the repository owner privately through the contact method
+listed on their GitHub profile and ask for a secure reporting channel.
+
+## Scope
+
+Please report vulnerabilities in the DatagramTunneler source code, official
+release artifacts, and the official Homebrew tap. Third-party builds and
+deployments may have their own reporting processes.


### PR DESCRIPTION
## Summary

Completes tasks 18, 19, and 21:

- Adds `SECURITY.md`, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md`.
- Adds bug and feature issue forms, a PR template, and maintainer ownership through `CODEOWNERS`.
- Clarifies the README’s use cases and limits, including how this differs from generic public-endpoint tools.
- Updates the repository description and adds accurate discovery topics for UDP multicast, LAN discovery, and network testing.

## Why

The project now gives users a safe security-reporting route, contributors a clear workflow, and prospective users technically precise guidance about whether DatagramTunneler fits their networking problem.

## Validation

- Parsed both GitHub issue-form YAML files with Ruby's YAML parser.
- Checked Markdown whitespace with `git diff --check`.
- Confirmed the build/test instructions match the current README.
- Read back the repository description and topics after updating them.

## Follow-up

Enable GitHub private vulnerability reporting in the repository Security settings before merging so the security policy’s primary reporting route is available.
